### PR TITLE
Add DOWNLOAD_DIR configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ More information can be found here: https://craig.chat/
 
 # Self-hosting/installation
 Detailed instructions on how to self-host Craig are located here: [SELFHOST.md](SELFHOST.md)
+
+## Environment variables
+
+The download API stores files in the `downloads` folder by default. Set the
+`DOWNLOAD_DIR` environment variable to override this location. Downloaded files
+are now kept indefinitely; adjust `apps/tasks/config/_default.js` if you wish to
+enable automatic cleanup.

--- a/apps/download/api/src/util/download.ts
+++ b/apps/download/api/src/util/download.ts
@@ -13,7 +13,9 @@ export interface DownloadState {
   type: string;
 }
 
-export const downloadPath = path.join(__dirname, '..', '..', 'downloads');
+export const downloadPath = process.env.DOWNLOAD_DIR
+  ? path.resolve(process.env.DOWNLOAD_DIR)
+  : path.join(__dirname, '..', '..', 'downloads');
 
 export async function writeToFile(
   stream: Readable,

--- a/apps/download/api/tsconfig.json
+++ b/apps/download/api/tsconfig.json
@@ -6,3 +6,4 @@
   },
   "include": ["./src/**/*"]
 }
+// Set DOWNLOAD_DIR to change the downloads folder used by the API

--- a/apps/tasks/config/_default.js
+++ b/apps/tasks/config/_default.js
@@ -36,7 +36,8 @@ module.exports = {
   },
 
   downloads: {
-    expiration: 24 * 60 * 60 * 1000,
+    // Set expiration to 0 to keep files indefinitely
+    expiration: 0,
     path: '../download/downloads'
   },
 

--- a/apps/tasks/src/jobs/cleanDownloads.ts
+++ b/apps/tasks/src/jobs/cleanDownloads.ts
@@ -6,7 +6,7 @@ import { TaskJob } from '../types';
 
 const downloadConfig = config.get('downloads') as {
   path: string;
-  expiration: number;
+  expiration?: number;
 };
 
 export default class CleanDownloads extends TaskJob {
@@ -18,14 +18,16 @@ export default class CleanDownloads extends TaskJob {
     this.logger.log('Cleaning downloads...');
     const downloadPath = path.join(__dirname, '..', '..', downloadConfig.path);
 
-    for (const file of await readdir(downloadPath)) {
-      try {
-        const s = await stat(path.join(downloadPath, file));
-        if (s.mtime.getTime() + downloadConfig.expiration < Date.now()) {
-          this.logger.log(`Deleting ${file}`);
-          await unlink(path.join(downloadPath, file));
-        }
-      } catch (e) {}
+    if (downloadConfig.expiration && downloadConfig.expiration > 0) {
+      for (const file of await readdir(downloadPath)) {
+        try {
+          const s = await stat(path.join(downloadPath, file));
+          if (s.mtime.getTime() + downloadConfig.expiration < Date.now()) {
+            this.logger.log(`Deleting ${file}`);
+            await unlink(path.join(downloadPath, file));
+          }
+        } catch (e) {}
+      }
     }
     this.logger.info('OK.');
   }


### PR DESCRIPTION
## Summary
- support custom downloads path with `DOWNLOAD_DIR`
- document the new variable
- keep downloaded files indefinitely by default

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `yarn lint` *(fails: ESLint couldn't find configuration file)*
- `yarn build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b90434cc8329a3b8237144d09739