### PR TITLE
Ensure downloads folder is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Detailed instructions on how to self-host Craig are located here: [SELFHOST.md](
 ## Environment variables
 
 The download API stores files in the `downloads` folder by default. Set the
-`DOWNLOAD_DIR` environment variable to override this location. Downloaded files
-are now kept indefinitely; adjust `apps/tasks/config/_default.js` if you wish to
-enable automatic cleanup.
+`DOWNLOAD_DIR` environment variable to override this location. The folder will
+be created automatically if it does not exist. Downloaded files are now kept
+indefinitely; adjust `apps/tasks/config/_default.js` if you wish to enable
+automatic cleanup.

--- a/apps/download/api/src/api.ts
+++ b/apps/download/api/src/api.ts
@@ -21,8 +21,10 @@ export let server: FastifyInstance;
 export async function start(): Promise<void> {
   try {
     await access(downloadPath);
+    console.info(`Using download directory ${downloadPath}`);
   } catch (e) {
-    await mkdir(downloadPath);
+    await mkdir(downloadPath, { recursive: true });
+    console.info(`Created download directory ${downloadPath}`);
   }
 
   await redisClient.connect();


### PR DESCRIPTION
## Summary
- create download directory recursively and log which folder is used
- document automatic creation of download folder

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `yarn lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_686581aa20388329a8dcdd8b4019cd5a